### PR TITLE
fix(cli): restore the build broken by the root-check refactor

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,6 @@ mod monitor;
 mod portal;
 mod ports;
 mod privs;
-mod recon;
 mod shell;
 mod signals;
 mod target;
@@ -898,9 +897,6 @@ enum GattCmd {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    if let Some(code) = maybe_reexec_root(&cli) {
-        return code;
-    }
     match run(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
@@ -1504,6 +1500,7 @@ fn cmd_wifi(cli: &Cli, oui_db: Option<&str>, action: &WifiCmd) -> Result<()> {
             return Ok(());
         }
         return print_networks(&nets, cli.json);
+    }
     // TUN needs root; fail before opening the device or picking a network.
     if matches!(action, WifiCmd::Adapter { .. }) {
         privs::require_root("wifi adapter")?;

--- a/cli/src/privs.rs
+++ b/cli/src/privs.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 /// Fail with a copy-pasteable `sudo /path/to/infishark...` when not root.
 pub fn require_root(feature: &str) -> Result<()> {
@@ -15,7 +15,7 @@ pub fn require_root(feature: &str) -> Result<()> {
                 .unwrap_or_else(|_| "infishark".into());
             let mut parts = vec![exe];
             parts.extend(std::env::args().skip(1));
-            bail!(
+            anyhow::bail!(
                 "{feature} needs root.\n\
                  This install is not on root's PATH; use:\n\
                    sudo {}",
@@ -113,11 +113,29 @@ mod tests {
 
     #[test]
     fn shell_quote_path_with_spaces() {
-        let p = "/home/user/documents/space space space/documents documents/ASCII char";
-        assert_eq!(shell_quote(p), "'/home/r00t/docs/shell direCtory'");
+        let p = "/home/user/my tools/infishark";
+        assert_eq!(shell_quote(p), "'/home/user/my tools/infishark'");
         assert_eq!(
             shell_join(&[p.into(), "wifi".into(), "adapter".into()]),
-            "'/home/1337/.local/bin/infishark' wifi adapter"
+            "'/home/user/my tools/infishark' wifi adapter"
         );
+    }
+
+    #[test]
+    fn shell_quote_escapes_embedded_single_quote() {
+        // The POSIX '\'' dance: close the quote, emit an escaped one, reopen.
+        assert_eq!(shell_quote("it's"), r#"'it'\''s'"#);
+    }
+
+    #[test]
+    fn shell_quote_leaves_plain_tokens_bare() {
+        assert_eq!(shell_quote("adapter"), "adapter");
+        assert_eq!(shell_quote("--ssid"), "--ssid");
+    }
+
+    #[test]
+    fn shell_quote_wraps_the_empty_token() {
+        // Without quoting, an empty arg would vanish from the pasted command.
+        assert_eq!(shell_quote(""), "''");
     }
 }

--- a/cli/src/shell.rs
+++ b/cli/src/shell.rs
@@ -248,22 +248,11 @@ impl Shell {
             .last()
             .map(|t| matches!(t, "--help" | "-h" | "help"))
             .unwrap_or(false);
-        // Pipes/redirects and root commands run through the system shell.
-        if !is_help {
-            let sudo = needs_sudo(line);
-            let piped = line.contains(['|', '>', '<']);
-            if sudo && piped {
-                eprintln!("a root command can't be piped");
-                return;
-            }
-            if piped {
-                self.run_external(line, false);
-                return;
-            }
-            if sudo {
-                self.run_external(line, true);
-                return;
-            }
+        // Pipes/redirects run through the system shell. Root-only commands run
+        // in-process; privs::require_root prints a pasteable sudo line if needed.
+        if !is_help && line.contains(['|', '>', '<']) {
+            self.run_external(line);
+            return;
         }
 
         let Some(toks) = shlex::split(line) else {
@@ -321,8 +310,8 @@ impl Shell {
         }
     }
 
-    // Re-run through the system shell so pipes work and sudo can prompt.
-    fn run_external(&self, line: &str, sudo: bool) {
+    // Re-run through the system shell so pipes and redirects work.
+    fn run_external(&self, line: &str) {
         let Ok(exe) = std::env::current_exe() else {
             eprintln!("cannot locate the infishark binary");
             return;


### PR DESCRIPTION
`main` has not compiled since c1cb7ca. `cargo build` fails at parse time, so every source install (the fallback path both installers take when no prebuilt binary matches) currently fails. The v0.1.0 release binary predates the commit, which is likely why this went unnoticed.

Four breakages, all from that one commit:

**1. `cmd_wifi` lost a closing brace.** The `if let WifiCmd::List = action` block never closes — the `require_root` insertion landed where the `}` was:

```
error: this file contains an unclosed delimiter
    --> cli/src/main.rs:2614:3
1499 | fn cmd_wifi(cli: &Cli, oui_db: Option<&str>, action: &WifiCmd) -> Result<()> {
     |                                                                              - unclosed delimiter
```

`v0.1.0` has that brace and the file balances at zero; HEAD has exactly one unclosed delimiter and it is this one.

**2. `mod recon;` has no module.** `cli/src/recon.rs` has never existed in any commit (`git log --all --diff-filter=AD -- cli/src/recon.rs` is empty), and nothing anywhere references `recon::`. I dropped the declaration rather than stub a module — happy to switch to a stub if `recon.rs` is real work-in-progress that just wasn't committed.

**3 & 4. Two orphaned call sites.** `maybe_reexec_root()` and `needs_sudo()` were both deleted, but `main()` and `shell.rs` still call them (`E0425` ×2).

I resolved 3 and 4 in the direction the refactor was already heading rather than restoring the helpers: `run_external()` had already lost its `sudo ` prefix logic, leaving its `sudo` parameter unread (hence the `unused variable` warning). So the sudo re-exec path is gone deliberately and `privs::require_root` prints the pasteable line instead. This PR removes the last references and the dead parameter. In the interactive shell, `wifi adapter` and `ble hid bridge` now run in-process and surface that same pasteable hint, instead of being silently re-run under `sudo`.

Two smaller things in the same commit:

- `privs.rs` imports `bail` but only uses it inside `#[cfg(unix)]`, so every Windows build warns.
- `shell_quote_path_with_spaces` asserts that quoting `/home/user/documents/space space space/...` yields `'/home/r00t/docs/shell direCtory'` — unrelated strings, so it can never pass. Retargeted at the real contract and added the embedded-single-quote, bare-token and empty-token cases, which had no coverage.

### Verification

`x86_64-pc-windows-gnu`, rustc 1.97.1:

```
cargo build --release     -> exit 0
cargo test --workspace    -> 136 passed; 0 failed
infishark ports           -> enumerates and probes correctly
```

### Worth considering separately

CI only triggers on `v*` tags, so nothing builds on push or PR — that is why a non-parsing `main` could sit for two days. A `cargo build` + `cargo test` job on push/PR would have caught all four of these. Glad to send that as a follow-up PR if useful.
